### PR TITLE
Bytestring version range change, for Snap 0.10 and GHC 7.6.1

### DIFF
--- a/snaplet-postgresql-simple.cabal
+++ b/snaplet-postgresql-simple.cabal
@@ -36,7 +36,7 @@ Library
 
   build-depends:
     base                       >= 4       && < 5,
-    bytestring                 >= 0.9.1   && < 0.10,
+    bytestring                 >= 0.9.1   && < 0.11,
     clientsession              >= 0.7.2   && < 0.9,
     configurator               >= 0.2     && < 0.3,
     errors                     >= 1.3     && < 1.4,


### PR DESCRIPTION
My Arch Linux GHC 7.6.1 has installed bytestring-0.10.0.0, and whilst this looks good for current Snap, wasn't allowed for this snaplet.
