### PR TITLE
Removed NOT NULL constraint from email field so Snap.Snaplet.Auth.create...

### DIFF
--- a/src/Snap/Snaplet/Auth/Backends/PostgresqlSimple.hs
+++ b/src/Snap/Snaplet/Auth/Backends/PostgresqlSimple.hs
@@ -35,7 +35,7 @@ module Snap.Snaplet.Auth.Backends.PostgresqlSimple
   ) where
 
 ------------------------------------------------------------------------------
-import           Prelude hiding (catch)
+import           Prelude
 import           Control.Error
 import           Control.Exception (SomeException, catch)
 import qualified Data.Configurator as C


### PR DESCRIPTION
I've removed the NOT NULL constraint from the "email" table column, because by default the Snap.Snaplet.Auth.createUser function will give a Nothing for the email field, causing it to fail.
