### PR TITLE
Allow snap version 0.11.*

### DIFF
--- a/snaplet-postgresql-simple.cabal
+++ b/snaplet-postgresql-simple.cabal
@@ -1,5 +1,5 @@
 name:           snaplet-postgresql-simple
-version:        0.3.0.1
+version:        0.3.0.2
 synopsis:       postgresql-simple snaplet for the Snap Framework
 description:    This snaplet contains support for using the Postgresql
                 database with a Snap Framework application via the
@@ -44,7 +44,7 @@ Library
     mtl                        >= 2       && < 3,
     postgresql-simple          >= 0.2     && < 0.3,
     resource-pool-catchio      >= 0.2     && < 0.3,
-    snap                       >= 0.10    && < 0.11,
+    snap                       >= 0.10    && < 0.12,
     text                       >= 0.11    && < 0.12,
     transformers               >= 0.2     && < 0.4,
     unordered-containers       >= 0.2     && < 0.3


### PR DESCRIPTION
I'm not sure if there's a particular reason to avoid allowing snap versions >= 0.11, but it seems to be working for me.
