### PR TITLE
Allow user table to have other columns than just those defined

### DIFF
--- a/src/Snap/Snaplet/Auth/Backends/PostgresqlSimple.hs
+++ b/src/Snap/Snaplet/Auth/Backends/PostgresqlSimple.hs
@@ -314,33 +314,36 @@ instance IAuthBackend PostgresAuthManager where
 
     lookupByUserId PostgresAuthManager{..} uid = do
         let q = Query $ T.encodeUtf8 $ T.concat
-                [ "select * from "
+                [ "select ", T.intercalate "," cols, " from "
                 , tblName pamTable
                 , " where "
                 , fst (colId pamTable)
                 , " = ?"
                 ]
         querySingle pamConnPool q [unUid uid]
+      where cols = map (fst . ($pamTable) . fst) colDef
 
     lookupByLogin PostgresAuthManager{..} login = do
         let q = Query $ T.encodeUtf8 $ T.concat
-                [ "select * from "
+                [ "select ", T.intercalate "," cols, " from "
                 , tblName pamTable
                 , " where "
                 , fst (colLogin pamTable)
                 , " = ?"
                 ]
         querySingle pamConnPool q [login]
+      where cols = map (fst . ($pamTable) . fst) colDef
 
     lookupByRememberToken PostgresAuthManager{..} token = do
         let q = Query $ T.encodeUtf8 $ T.concat
-                [ "select * from "
+                [ "select ", T.intercalate "," cols, " from "
                 , tblName pamTable
                 , " where "
                 , fst (colRememberToken pamTable)
                 , " = ?"
                 ]
         querySingle pamConnPool q [token]
+      where cols = map (fst . ($pamTable) . fst) colDef
 
     destroy PostgresAuthManager{..} AuthUser{..} = do
         let q = Query $ T.encodeUtf8 $ T.concat


### PR DESCRIPTION
As it currently stands, if you add a column to the user table, any attempt to user snap-auth will fail, as there are too many columns returned. This is an unnecessary restriction - we know all the columns we want, and can specify them explicitly.
