### PR TITLE
Support postgresql-simple >= 0.3

### DIFF
--- a/snaplet-postgresql-simple.cabal
+++ b/snaplet-postgresql-simple.cabal
@@ -1,5 +1,5 @@
 name:           snaplet-postgresql-simple
-version:        0.3.0.3
+version:        0.3.0.4
 synopsis:       postgresql-simple snaplet for the Snap Framework
 description:    This snaplet contains support for using the Postgresql
                 database with a Snap Framework application via the
@@ -42,7 +42,7 @@ Library
     errors                     >= 1.4     && < 1.5,
     MonadCatchIO-transformers  >= 0.3     && < 0.4,
     mtl                        >= 2       && < 3,
-    postgresql-simple          >= 0.2     && < 0.3,
+    postgresql-simple          >= 0.3     && < 0.4,
     resource-pool-catchio      >= 0.2     && < 0.3,
     snap                       >= 0.10    && < 0.12,
     text                       >= 0.11    && < 0.12,

--- a/src/Snap/Snaplet/PostgresqlSimple.hs
+++ b/src/Snap/Snaplet/PostgresqlSimple.hs
@@ -126,6 +126,7 @@ import           Data.Pool
 import           Database.PostgreSQL.Simple.ToRow
 import           Database.PostgreSQL.Simple.FromRow
 import qualified Database.PostgreSQL.Simple as P
+import qualified Database.PostgreSQL.Simple.Transaction as P
 import           Snap
 import           Paths_snaplet_postgresql_simple
 


### PR DESCRIPTION
I wrote some code against `postgresql-simple-0.3.0.1`. Then I wanted to combine that with a webserver I was writing using Snap. Found this excellent package, but version conflicts ensued.

Note that this fix is not compatible with `postgresql-simple < 0.3`. Is this acceptable? Otherwise backwards compatibility could be achieved using a cabal flag and some CPP. 
