### PR TITLE
Allow connection configuration from an environment variable.

### DIFF
--- a/snaplet-postgresql-simple.cabal
+++ b/snaplet-postgresql-simple.cabal
@@ -47,8 +47,8 @@ Library
     snap                       >= 0.10    && < 0.14,
     text                       >= 0.11.2  && < 1.2,
     transformers               >= 0.2     && < 0.4,
-    unordered-containers       >= 0.2     && < 0.3
-
+    unordered-containers       >= 0.2     && < 0.3,
+    unix                       >= 2.6     && < 2.7
 
   ghc-options: -Wall -fwarn-tabs -funbox-strict-fields
                -fno-warn-orphans -fno-warn-unused-do-bind


### PR DESCRIPTION
This commit exposes a new function for initialization of a db connection from an environment variable. This is particularly important for users of Heroku, since Heroku database configuration needs to be read from an environment variable.

If there is an easier way to read the database URL from an environment variable than making this patch (either to this library or our own application) please let me know, and perhaps we can figure out a way to improve documentation for future users of this library in environments like Heroku. Thanks!
