### PR TITLE
Code cleanup for 1.0

### DIFF
--- a/snaplet-postgresql-simple.cabal
+++ b/snaplet-postgresql-simple.cabal
@@ -41,15 +41,16 @@ Library
     clientsession              >= 0.7.2   && < 0.10,
     configurator               >= 0.2     && < 0.4,
     errors                     >= 1.4     && < 1.5,
-    lens,
-    lifted-base,
-    monad-control,
+    lens                                     < 4.10,
+    lifted-base                >= 0.2     && < 0.3,
+    monad-control              >= 1.0     && < 1.1,
     mtl                        >= 2       && < 2.3,
     postgresql-simple          >= 0.3     && < 0.5,
-    resource-pool,
-    snap                       >= 1.0,
+    resource-pool              >= 0.2     && < 0.3,
+    snap                       >= 1.0     && < 1.1,
     text                       >= 0.11    && < 1.3,
     transformers               >= 0.2     && < 0.5,
+    transformers-base          >= 0.4     && < 0.5,
     unordered-containers       >= 0.2     && < 0.3
 
 

--- a/src/Snap/Snaplet/Auth/Backends/PostgresqlSimple.hs
+++ b/src/Snap/Snaplet/Auth/Backends/PostgresqlSimple.hs
@@ -35,7 +35,7 @@ module Snap.Snaplet.Auth.Backends.PostgresqlSimple
   ) where
 
 ------------------------------------------------------------------------------
-import           Prelude
+import           Control.Applicative
 import           Control.Error
 import qualified Control.Exception as E
 import           Control.Lens ((^#))

--- a/src/Snap/Snaplet/PostgresqlSimple/Internal.hs
+++ b/src/Snap/Snaplet/PostgresqlSimple/Internal.hs
@@ -5,9 +5,8 @@
 
 module Snap.Snaplet.PostgresqlSimple.Internal where
 
-import           Prelude hiding ((++))
-import           Control.Monad.Trans.Control
 import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Control (MonadBaseControl(..))
 import           Data.ByteString (ByteString)
 import           Data.Pool
 import qualified Database.PostgreSQL.Simple as P


### PR DESCRIPTION
Just switching my 1.0 fork to your 1.0 branch

Put bounds on snap, resource-pool, lifted-base, monad-control and lens
(<>) operator is part of base since 7.2, no need for ++
Explicitly list some imports
Switch to fmap from (<$>) to make it work without Control.Applicative
on older GHC
Do import Control.Applicative in Auth/Backend for ghc < 7.10