### PR TITLE
Added better documentation around the withPG function.

### DIFF
--- a/src/Snap/Snaplet/PostgresqlSimple.hs
+++ b/src/Snap/Snaplet/PostgresqlSimple.hs
@@ -48,6 +48,14 @@ With this code, our postHandler example no longer requires the 'with' function:
 >     posts <- query_ "select * from blog_post"
 >     ...
 
+If you have code that runs multiple queries but you want to make sure that you only use one database connection then you can use the withPG function, like so:
+
+> postHandler :: Handler App App ()
+> postHandler = withPG $ do
+>     posts <- query_ "select * from blog_post"
+>     links <- query_ "select * from links"
+>     ...
+
 The first time you run an application with the postgresql-simple snaplet, a
 configuration file @devel.cfg@ is created in the @snaplets/postgresql-simple@
 directory underneath your project root.  It specifies how to connect to your

--- a/src/Snap/Snaplet/PostgresqlSimple/Internal.hs
+++ b/src/Snap/Snaplet/PostgresqlSimple/Internal.hs
@@ -60,7 +60,22 @@ pgsDefaultConfig connstr = PGSConfig connstr 1 5 20
 
 ------------------------------------------------------------------------------
 -- | Function that reserves a single connection for the duration of the given
---   action.
+-- action. Nested calls to withPG will only reserve one connection. For example,
+-- the following code calls withPG twice in a nested way yet only results in a single
+-- connection being reserved:
+-- 
+-- > myHandler = withPG $ do
+-- >    queryTheDatabase
+-- >    commonDatabaseMethod
+-- >
+-- > commonDatabaseMethod = withPG $ do
+-- >    moreDatabaseActions
+-- >    evenMoreDatabaseActions
+--
+-- This is useful in a practical setting because you may often find yourself in a situation
+-- where you have common code (that requires a database connection) that you wish to call from 
+-- other blocks of code that may require a database connection and you still want to make sure
+-- that you are only using one connection through all of your nested methods.
 withPG :: (HasPostgres m)
        => m b -> m b
 withPG f = do


### PR DESCRIPTION
## Description

And also explicitly call it out in the front page documentation. Hopefully this will increase
adoption and prevent plenty of poorly written code as I was originally doing.

The most important note that I have made is that calls to withPG can be nested safely and still only result in a single Connection being reserved.

## Screenshots

In the initial documentation:
![screen shot 2015-05-31 at 3 16 10 pm](https://cloud.githubusercontent.com/assets/149178/7900652/805e33b6-07a8-11e5-861d-9af234c1c246.png)

In the withPG method:
![screen shot 2015-05-31 at 3 15 58 pm](https://cloud.githubusercontent.com/assets/149178/7900653/8061a96a-07a8-11e5-8e82-36c7d7490b2e.png)
