### PR TITLE
Generalize liftPG to any monad

### DIFF
--- a/src/Snap/Snaplet/Auth/Backends/PostgresqlSimple.hs
+++ b/src/Snap/Snaplet/Auth/Backends/PostgresqlSimple.hs
@@ -103,7 +103,7 @@ initPostgresAuth sess db = makeSnaplet "postgresql-auth" desc datadir $ do
 -- | Create the user table if it doesn't exist.
 createTableIfMissing :: PostgresAuthManager -> IO ()
 createTableIfMissing PostgresAuthManager{..} = do
-    liftPG' pamConn $ \conn -> do
+    withConnection pamConn $ \conn -> do
         res <- P.query_ conn $ Query $ T.encodeUtf8 $
           "select relname from pg_class where relname='"
           `T.append` schemaless (tblName pamTable) `T.append` "'"
@@ -178,13 +178,13 @@ instance FromRow AuthUser where
 
 querySingle :: (ToRow q, FromRow a)
             => Postgres -> Query -> q -> IO (Maybe a)
-querySingle pc q ps = liftPG' pc $ \conn -> return . listToMaybe =<<
+querySingle pc q ps = withConnection pc $ \conn -> return . listToMaybe =<<
     P.query conn q ps
 
 authExecute :: ToRow q
             => Postgres -> Query -> q -> IO ()
 authExecute pc q ps = do
-    liftPG' pc $ \conn -> P.execute conn q ps
+    withConnection pc $ \conn -> P.execute conn q ps
     return ()
 
 instance P.ToField Password where
@@ -309,7 +309,7 @@ instance IAuthBackend PostgresAuthManager where
     save PostgresAuthManager{..} u@AuthUser{..} = do
         let (qstr, params) = saveQuery pamTable u
         let q = Query $ T.encodeUtf8 qstr
-        let action = liftPG' pamConn $ \conn -> do
+        let action = withConnection pamConn $ \conn -> do
                 res <- P.query conn q params
                 return $ Right $ fromMaybe u $ listToMaybe res
         E.catch action onFailure


### PR DESCRIPTION
This is useful if you want to use connection from IO callback. Alternatively  we could export withConnection (former liftPG'). That can actually be a good idea in addition to liftPG change.
Added Connection to exports to simplify imports for user.

Rename original liftPG to liftPG' as one specialized to IO for internal use.
And liftPG' renamed to withConnection, for better code readability.