### PR TITLE
Allow lens 4.12

### DIFF
--- a/snaplet-postgresql-simple.cabal
+++ b/snaplet-postgresql-simple.cabal
@@ -41,7 +41,7 @@ Library
     clientsession              >= 0.7.2   && < 0.10,
     configurator               >= 0.2     && < 0.4,
     errors                     >= 1.4     && < 1.5,
-    lens                                     < 4.12,
+    lens                                     < 4.13,
     MonadCatchIO-transformers  >= 0.3     && < 0.4,
     mtl                        >= 2       && < 2.3,
     postgresql-simple          >= 0.3     && < 0.5,


### PR DESCRIPTION
snaplet-postgresql-simple seems to build and run with lens 4.12.3 (the latest), and presumably then 4.12.*. 