### PR TITLE
Allow transformers 0.5

### DIFF
--- a/snaplet-postgresql-simple.cabal
+++ b/snaplet-postgresql-simple.cabal
@@ -51,7 +51,7 @@ Library
     resource-pool              >= 0.2     && < 0.3,
     snap                       >= 1.0     && < 1.1,
     text                       >= 0.11    && < 1.3,
-    transformers               >= 0.2     && < 0.5,
+    transformers               >= 0.2     && < 0.6,
     transformers-base          >= 0.4     && < 0.5,
     unordered-containers       >= 0.2     && < 0.3
 


### PR DESCRIPTION
Hi Doug,

This is for GHC 8 support. I see you bumped `base` (#39); not sure if there's anything else that needs to be done besides this.

Brian