### PR TITLE
Export liftPG'

### DIFF
--- a/src/Snap/Snaplet/PostgresqlSimple.hs
+++ b/src/Snap/Snaplet/PostgresqlSimple.hs
@@ -80,6 +80,7 @@ module Snap.Snaplet.PostgresqlSimple (
   , withPG
   , P.Connection
   , liftPG
+  , liftPG'
 
   -- * Wrappers and re-exports
   , query


### PR DESCRIPTION
Hi Doug,

I've exported `liftPG'` so that users can lift raw postgresql-simple interactions into Snap.

The motivation is that I have some DB code that I'd like to be able to use both within and outside of Snap; hopefully I haven't missed a proper way to do this that the library already enables.

Thanks,
Brian