### PR TITLE
Extend support to more recent GHC.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.10
+# version: 0.10.3
 #
 version: ~> 1.0
 language: c
@@ -33,6 +33,9 @@ before_cache:
   - rm -rfv $CABALHOME/packages/head.hackage
 jobs:
   include:
+    - compiler: ghc-8.10.2
+      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.10.2","cabal-install-3.2"]}}
+      os: linux
     - compiler: ghc-8.8.3
       addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.8.3","cabal-install-3.2"]}}
       os: linux
@@ -149,5 +152,5 @@ script:
   - rm -f cabal.project.local
   - ${CABAL} v2-build $WITHCOMPILER --disable-tests --disable-benchmarks all
 
-# REGENDATA ("0.10",["snaplet-postgresql-simple.cabal","--output",".travis.yml"])
+# REGENDATA ("0.10.3",["snaplet-postgresql-simple.cabal","--output",".travis.yml"])
 # EOF

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,6 @@
+packages: ./snaplet-postgresql-simple.cabal
+
+source-repository-package
+    type: git
+    location: https://github.com/uffizio/snap.git
+    tag: master

--- a/snaplet-postgresql-simple.cabal
+++ b/snaplet-postgresql-simple.cabal
@@ -21,7 +21,8 @@ tested-with:
   GHC == 8.2.2,
   GHC == 8.4.3,
   GHC == 8.6.4,
-  GHC == 8.8.3
+  GHC == 8.8.3,
+  GHC == 8.10.2
 
 extra-source-files:
   LICENSE
@@ -52,7 +53,7 @@ Library
     Paths_snaplet_postgresql_simple
 
   build-depends:
-    base                       >= 4       && < 4.14,
+    base                       >= 4       && < 4.15,
     bytestring                 >= 0.9.1   && < 0.11,
     clientsession              >= 0.7.2   && < 0.10,
     configurator               >= 0.2     && < 0.4,


### PR DESCRIPTION
I could not use this package with GHC 8.10, so I bumped some version bounds and adjusted Travis configuration as appropriate. Would be great if you can merge and make a Hackage release.

Note that it will not build on Travis until snapframework/snap#218 is merged and published. I checked and re-checked that it builds locally with the latest three major GHC releases. You should also remove `cabal.project` then — it is only here to command Cabal to build with [our updated fork of `snap`][snap] as a dependency.

[snap]: https://github.com/uffizio/snap